### PR TITLE
make the Makefile be friendly to people who build their own lilv (lilv 0...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 LIBS = -ljack `pkg-config --libs lilv-0` -largtable2 -lreadline -lpthread
 
 # additional include paths
-INCS = -I/usr/include/lilv-0
+INCS = -I/usr/include/lilv-0 -I/usr/local/include/lilv-0
 
 # remove command
 RM = rm -f


### PR DESCRIPTION
....5 which is packaged for Trisquel GNU/Linux 6.0 is too old)
