### PR TITLE
Fix rounding errors in LV2 barBeat

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -905,7 +905,7 @@ static int ProcessPlugin(jack_nframes_t nframes, void *arg)
                 lv2_atom_forge_long(&forge, pos.bar - 1);
 
                 lv2_atom_forge_key(&forge, g_urids.time_barBeat);
-                lv2_atom_forge_float(&forge, pos.beat - 1 + (pos.tick / pos.ticks_per_beat));
+                lv2_atom_forge_float(&forge, pos.beat - 1 + (g_transport_tick / pos.ticks_per_beat));
 
                 lv2_atom_forge_key(&forge, g_urids.time_beat);
                 lv2_atom_forge_double(&forge, pos.beat - 1);


### PR DESCRIPTION
Code was using jack_pos.tick, which is an int (rounded from the global double-precision tick value)
This loses precision, as the global tick has decimal values when the BPM is fractional.
Using the double-precision tick we avoid rounding errors.
Likely fixes #27

NOTE: there was a discussion about this on #lv2 irc channel on freenode,
I advise current MOD devs to keep an eye on it.