### PR TITLE
Add ability to give a name to jack client

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -2448,7 +2448,7 @@ int effects_finish(int close_client)
     return SUCCESS;
 }
 
-int effects_add(const char *uid, int instance)
+int effects_add(const char *uid, int instance, const char *jack_client_name)
 {
     unsigned int i, ports_count;
     char effect_name[32], port_name[MAX_CHAR_BUF_SIZE+1];
@@ -2526,7 +2526,14 @@ int effects_add(const char *uid, int instance)
     lilv_license_interface = NULL;
 
     /* Create a client to Jack */
-    snprintf(effect_name, 31, "effect_%i", instance);
+    if (jack_client_name)
+    {
+        strncpy(effect_name, jack_client_name, 31);
+    }
+    else
+    {
+        snprintf(effect_name, 31, "effect_%i", instance);
+    }
     jack_client = jack_client_open(effect_name, JackNoStartServer, &jack_status);
 
     if (!jack_client)

--- a/src/effects.h
+++ b/src/effects.h
@@ -121,7 +121,7 @@ typedef struct {
 
 int effects_init(void* client);
 int effects_finish(int close_client);
-int effects_add(const char *uid, int instance);
+int effects_add(const char *uid, int instance, const char *jack_client_name);
 int effects_remove(int effect_id);
 int effects_preset_load(int effect_id, const char *uri);
 int effects_preset_save(int effect_id, const char *dir, const char *file_name, const char *label);

--- a/src/mod-host.c
+++ b/src/mod-host.c
@@ -127,7 +127,12 @@ static pthread_t intclient_socket_thread;
 static void effects_add_cb(proto_t *proto)
 {
     int resp;
-    resp = effects_add(proto->list[1], atoi(proto->list[2]));
+    char *jack_client_name = NULL;
+    if (proto->list_count == 4)
+    {
+        jack_client_name = proto->list[3];
+    }
+    resp = effects_add(proto->list[1], atoi(proto->list[2]), jack_client_name);
 
     char buffer[128];
     sprintf(buffer, "resp %i", resp);

--- a/src/mod-host.h
+++ b/src/mod-host.h
@@ -51,7 +51,7 @@
 #define SOCKET_MSG_BUFFER_SIZE  1024
 
 /* Protocol commands definition */
-#define EFFECT_ADD          "add %s %i"
+#define EFFECT_ADD          "add %s %i ..."
 #define EFFECT_REMOVE       "remove %i"
 #define EFFECT_PRESET_LOAD  "preset_load %i %s"
 #define EFFECT_PRESET_SAVE  "preset_save %i %s %s %s"

--- a/tests/effectlib_test.c
+++ b/tests/effectlib_test.c
@@ -14,7 +14,7 @@ int main (void)
     if (effects_init(NULL) == 0)
     {
         action = "add: http://lv2plug.in/plugins/eg-amp";
-        ret = effects_add("http://lv2plug.in/plugins/eg-amp", 0);
+        ret = effects_add("http://lv2plug.in/plugins/eg-amp", 0, NULL);
         printf("%s, ret: %i\n", action, ret);
 
         if (ret != 0)


### PR DESCRIPTION
I have to interface with effects outside of mod-host, and having all those effect_* jack clients was getting confusing. Here's a pull request adding an optional argument to "add" command that allows specifying a name for the jack client.

Feel free to comment, reject, merge ;)

Thanks for mod-host, it's awesome.