### PR TITLE
Add help output for -n/--nofork

### DIFF
--- a/src/mod-host.c
+++ b/src/mod-host.c
@@ -787,6 +787,7 @@ int main(int argc, char **argv)
 #ifndef SKIP_READLINE
                     "  -i, --interactive              interactive mode\n"
 #endif
+                    "  -n, --nofork                   run in nonforking mode\n"
                     "  -V, --version                  print program version and exit\n"
                     "  -h, --help                     print this help and exit\n",
                 argv[0]);


### PR DESCRIPTION
That option is mentioned where the README explains how to run mod-host, but isn't mentioned in --help as of yet.