### PR TITLE
Hotfix 1.11 midi cc out

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -5937,11 +5937,17 @@ int effects_set_parameter(int effect_id, const char *control_symbol, float value
                         break;
                     if (g_midi_cc_list[j].effect_id == ASSIGNMENT_UNUSED)
                         continue;
-                    if (g_midi_cc_list[j].effect_id  == effect_id &&
-                        strcmp(g_midi_cc_list[j].symbol, control_symbol) == 0)
-                    {
-                        SetMidiOutValue(&(g_midi_cc_list[j]));
+                    if (g_midi_cc_list[j].effect_id  == effect_id)
+                    { 
+                        // avoid call to strcmp and compare strings ourselves
+                        bool bEqual = false;
+                        for(const char *s1 = control_symbol, *s2 = g_midi_cc_list[j].symbol; (bEqual = *s1 == *s2) && *s1; s1++, s2++)
+                            /* empty loop*/;
+
+                        if(bEqual)
+                            SetMidiOutValue(&(g_midi_cc_list[j]));
                     }
+                    
                 }
             }
             return SUCCESS;


### PR DESCRIPTION
Adds midi out of CC messages that have been mapped to parameters.

This allows midi controllers to be kept in sync with parameter values (if they support it).

Works with UI Knobs, initial mapping, snapshot loading and pedalboard loading.

Enabled with the env var ENABLE_MIDI_FEEDBACK

       ENABLE_MIDI_FEEDBACK = 1 : Enable midi CC feedback
       ENABLE_MIDI_FEEDBACK = 2 : Enable midi CC feedback and also sync devices on input

Tested on ModDwarf with both Aggregated and Separate modes. Tested with USB midi controllers connected directly and over the hardware midi.
