### PR TITLE
add summed bypass (to enable delay tails to go on after bypassing)

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -1963,17 +1963,14 @@ static int ProcessPlugin(jack_nframes_t nframes, void *arg)
             /* Run the plugin with zero buffer to avoid 'pause behavior' in delay plugins */
             lilv_instance_run(effect->lilv_instance, nframes);
 
-            if (effect->bypass > 1.5f)
+            for (i = 0; i < effect->output_audio_ports_count; i++)
             {
-                for (i = 0; i < effect->output_audio_ports_count; i++)
+                float *buffer_out = (float*)jack_port_get_buffer(effect->output_audio_ports[i]->jack_port, nframes);
+                for (jack_nframes_t frame = 0; frame < nframes; ++frame)
                 {
-                  float *buffer_out = (float*)jack_port_get_buffer(effect->output_audio_ports[i]->jack_port, nframes);
-                  for (jack_nframes_t frame = 0; frame < nframes; ++frame)
-                  {
                     buffer_out[frame] += ((float*)effect->output_audio_ports[i]->buffer)[frame];
-                  }
-                } 
-            }
+                }
+            } 
             /* no need to silence plugin audio or cv, they are unused during bypass */
         }
         /* Plugins without audio inputs */

--- a/src/effects.c
+++ b/src/effects.c
@@ -1963,6 +1963,17 @@ static int ProcessPlugin(jack_nframes_t nframes, void *arg)
             /* Run the plugin with zero buffer to avoid 'pause behavior' in delay plugins */
             lilv_instance_run(effect->lilv_instance, nframes);
 
+            if (effect->bypass > 1.5f)
+            {
+                for (i = 0; i < effect->output_audio_ports_count; i++)
+                {
+                  float *buffer_out = (float*)jack_port_get_buffer(effect->output_audio_ports[i]->jack_port, nframes);
+                  for (jack_nframes_t frame = 0; frame < nframes; ++frame)
+                  {
+                    buffer_out[frame] += ((float*)effect->output_audio_ports[i]->buffer)[frame];
+                  }
+                } 
+            }
             /* no need to silence plugin audio or cv, they are unused during bypass */
         }
         /* Plugins without audio inputs */


### PR DESCRIPTION
This is a simple hack to allow delay tails go on after bypassing a delay plugin.. 