### PR TITLE
Midi cc out nrpn

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -246,7 +246,8 @@ enum PostPonedEventType {
     POSTPONED_MIDI_PROGRAM_CHANGE,
     POSTPONED_MIDI_MAP,
     POSTPONED_TRANSPORT,
-    POSTPONED_JACK_MIDI_CONNECT,
+    POSTPONED_JACK_MIDI_CONNECT_IN,
+    POSTPONED_JACK_MIDI_CONNECT_OUT,
     POSTPONED_LOG_TRACE, // stack allocated, rt-safe
     POSTPONED_LOG_MESSAGE, // heap allocated
     POSTPONED_PROCESS_OUTPUT_BUFFER
@@ -515,6 +516,7 @@ typedef struct MIDI_CC_T {
     int effect_id;
     const char* symbol;
     port_t* port;
+    int8_t midiOutValue;
 } midi_cc_t;
 
 typedef struct ASSIGNMENT_T {
@@ -679,6 +681,7 @@ static jack_port_t *g_audio_out1_port;
 static jack_port_t *g_audio_out2_port;
 #endif
 static jack_port_t *g_midi_in_port;
+static jack_port_t *g_midi_out_port;
 static jack_position_t g_jack_pos;
 static bool g_jack_rolling;
 static volatile double g_transport_bpb;
@@ -688,6 +691,8 @@ static volatile enum TransportSyncMode g_transport_sync_mode;
 static bool g_aggregated_midi_enabled;
 static bool g_processing_enabled;
 static bool g_verbose_debug;
+static bool g_enable_midi_feedback;
+static bool g_enable_midi_feedback_sync;
 
 // Wall clock time since program startup
 static uint64_t g_monotonic_frame_count = 0;
@@ -773,7 +778,7 @@ static const char* const g_rolling_port_symbol = ROLLING_PORT_SYMBOL;
 *           LOCAL FUNCTION PROTOTYPES
 ************************************************************************************************************************
 */
-
+static void SetMidiOutValue(midi_cc_t *midiCC);
 static void InstanceDelete(int effect_id);
 static int InstanceExist(int effect_id);
 static void AllocatePortBuffers(effect_t* effect, int in_size, int out_size);
@@ -875,6 +880,38 @@ static char* strchrnul(const char *s, int c)
     return r;
 }
 #endif
+
+#ifdef ENABLE_TMP_LOG
+static void Log(const char *psFormatString, ...)
+{
+    static FILE *pFile = NULL;
+    static char logStr[2048];
+
+    if(pFile == NULL)
+    {
+        pFile = fopen("/tmp/mod.log", "a");
+    }
+    
+	va_list args;
+	va_start(args, psFormatString);
+
+    vsnprintf(logStr, 2048, psFormatString, args);
+
+    fputs(logStr, pFile);
+
+    fflush(pFile);
+}
+#endif
+
+static void SetMidiOutValue(midi_cc_t *midiCC)
+{
+    float value = *(midiCC->port->buffer);
+
+    float fRange = midiCC->maximum - midiCC->minimum;
+    float fNormal = (value - midiCC->minimum) / fRange;
+
+    midiCC->midiOutValue = fNormal * 127;
+}
 
 static void InstanceDelete(int effect_id)
 {
@@ -995,13 +1032,25 @@ static void PortRegistration(jack_port_id_t port_id, int reg, void* data)
         return;
 
     /* port flags to connect to */
-    static const int target_port_flags = JackPortIsTerminal|JackPortIsPhysical|JackPortIsOutput;
+    static const int target_port_flags_out = JackPortIsTerminal|JackPortIsPhysical|JackPortIsOutput;
+    static const int target_port_flags_in  = JackPortIsTerminal|JackPortIsPhysical|JackPortIsInput;
 
     const jack_port_t* const port = jack_port_by_id(g_jack_global_client, port_id);
 
-    if ((jack_port_flags(port) & target_port_flags) != target_port_flags)
+    if (((jack_port_flags(port) & target_port_flags_out) != target_port_flags_out) && ((jack_port_flags(port) & target_port_flags_in) != target_port_flags_in))
         return;
+
     if (strcmp(jack_port_type(port), JACK_DEFAULT_MIDI_TYPE) != 0)
+        return;
+		
+	
+    enum PostPonedEventType eventType;
+    
+    if ((jack_port_flags(port) & target_port_flags_out) == target_port_flags_out)
+        eventType = POSTPONED_JACK_MIDI_CONNECT_OUT;
+    else if ((jack_port_flags(port) & target_port_flags_in) == target_port_flags_in)
+        eventType = POSTPONED_JACK_MIDI_CONNECT_IN;
+    else
         return;
 
     postponed_event_list_data* const posteventptr = rtsafe_memory_pool_allocate_atomic(g_rtsafe_mem_pool);
@@ -1009,7 +1058,7 @@ static void PortRegistration(jack_port_id_t port_id, int reg, void* data)
     if (posteventptr == NULL)
         return;
 
-    posteventptr->event.type = POSTPONED_JACK_MIDI_CONNECT;
+    posteventptr->event.type = eventType;
     posteventptr->event.jack_midi_connect.port = port_id;
 
     pthread_mutex_lock(&g_rtsafe_mutex);
@@ -1181,7 +1230,7 @@ static void RunPostPonedEvents(int ignored_effect_id)
         }
 #endif
 
-        if (got_only_jack_midi_requests && eventptr->event.type != POSTPONED_JACK_MIDI_CONNECT)
+        if (got_only_jack_midi_requests && !(eventptr->event.type == POSTPONED_JACK_MIDI_CONNECT_OUT || eventptr->event.type == POSTPONED_JACK_MIDI_CONNECT_IN))
             got_only_jack_midi_requests = false;
 
         switch (eventptr->event.type)
@@ -1263,7 +1312,7 @@ static void RunPostPonedEvents(int ignored_effect_id)
             got_transport = true;
             break;
 
-        case POSTPONED_JACK_MIDI_CONNECT:
+        case POSTPONED_JACK_MIDI_CONNECT_OUT:
             if (g_jack_global_client != NULL) {
                 const jack_port_id_t port_id = eventptr->event.jack_midi_connect.port;
                 const jack_port_t *const port = jack_port_by_id(g_jack_global_client, port_id);
@@ -1286,6 +1335,21 @@ static void RunPostPonedEvents(int ignored_effect_id)
                 }
             }
             break;
+
+        case POSTPONED_JACK_MIDI_CONNECT_IN:
+            if(g_enable_midi_feedback && g_jack_global_client != NULL) {
+                const jack_port_id_t port_id = eventptr->event.jack_midi_connect.port;
+                const jack_port_t *const port = jack_port_by_id(g_jack_global_client, port_id);
+
+                if (port != NULL) {
+                    if(g_midi_out_port != NULL)
+                    {
+                        jack_connect(g_jack_global_client,  jack_port_name(g_midi_out_port), jack_port_name(port));
+                    }
+                }
+            }
+            break;
+
 
         case POSTPONED_PROCESS_OUTPUT_BUFFER:
             if (eventptr->event.process_out_buf.effect_id == ignored_effect_id)
@@ -2457,7 +2521,32 @@ static int ProcessGlobalClient(jack_nframes_t nframes, void *arg)
         }
     }
 #endif
-
+    // If midi feedback is enabled send any cc messages out to midi
+    if(g_enable_midi_feedback)
+    {
+        void *buf = jack_port_get_buffer(g_midi_out_port, nframes);
+        if (buf != NULL)
+        {
+            jack_midi_clear_buffer(buf);
+            for (int j = 0; j < MAX_MIDI_CC_ASSIGN; j++)
+            {
+                if (g_midi_cc_list[j].effect_id == ASSIGNMENT_NULL)
+                    break;
+                if (g_midi_cc_list[j].effect_id == ASSIGNMENT_UNUSED)
+                    continue;
+                if (g_midi_cc_list[j].midiOutValue >= 0)
+                {
+                    jack_midi_data_t buffer[3];
+                    buffer [0] = 0xb0 + g_midi_cc_list[j].channel;
+                    buffer [1] = g_midi_cc_list[j].controller;
+                    buffer [2] = g_midi_cc_list[j].midiOutValue;
+                    g_midi_cc_list[j].midiOutValue = -1;
+                    if(jack_midi_event_write(buf, 0, buffer,3))
+                        break;
+                }
+            }
+        }
+    }
     // Handle input MIDI events
     void *const port_buf = jack_port_get_buffer(g_midi_in_port, nframes);
     const jack_nframes_t event_count = jack_midi_get_event_count(port_buf);
@@ -2598,6 +2687,11 @@ static int ProcessGlobalClient(jack_nframes_t nframes, void *arg)
             {
                 handled = true;
                 value = UpdateValueFromMidi(&g_midi_cc_list[j], mvalue, highres);
+
+                // if midi feedback sync is enabled set the output CC to send back out over midi
+                // this will keep any other devices synced.
+                if(g_enable_midi_feedback_sync)
+                    SetMidiOutValue(&(g_midi_cc_list[j]));
 
                 postponed_event_list_data* const posteventptr = rtsafe_memory_pool_allocate_atomic(g_rtsafe_mem_pool);
 
@@ -3124,6 +3218,41 @@ static void ConnectToAllHardwareMIDIPorts(void)
         pthread_mutex_unlock(&g_raw_midi_port_mutex);
 
         jack_free(midihwports);
+    }
+
+    if(g_enable_midi_feedback)
+    {
+        const char** const midihwports = jack_get_ports(g_jack_global_client, "",
+                                                        JACK_DEFAULT_MIDI_TYPE,
+                                                        JackPortIsTerminal|JackPortIsPhysical|JackPortIsInput);
+        if (midihwports != NULL)
+        {
+            const char *ourportname = jack_port_name(g_midi_out_port);
+
+            char  aliases[2][320];
+            char* aliasesptr[2] = {
+                aliases[0],
+                aliases[1]
+            };
+
+            for (int i=0; midihwports[i] != NULL; ++i)
+            {
+                jack_port_t* const port = jack_port_by_name(g_jack_global_client, midihwports[i]);
+
+                if (port == NULL)
+                    continue;
+
+                if (jack_port_get_aliases(port, aliasesptr) > 0)
+                {
+                    if (strncmp(aliases[0], "alsa_pcm:Midi-Through/", 22) == 0)
+                        continue;
+                }
+
+                jack_connect(g_jack_global_client, ourportname, midihwports[i]);
+            }
+
+            jack_free(midihwports);
+        }
     }
 }
 
@@ -3773,7 +3902,28 @@ int effects_init(void* client)
             jack_client_close(g_jack_global_client);
         return ERR_JACK_PORT_REGISTER;
     }
+	
+    /* check midi feedback mode 
+       ENABLE_MIDI_FEEDBACK = 1 : Enable midi CC feedback
+       ENABLE_MIDI_FEEDBACK = 2 : Enable midi CC feedback and also sync devices on input */
 
+    const char* const enable_midi_feedback = getenv("ENABLE_MIDI_FEEDBACK");
+    g_enable_midi_feedback      = enable_midi_feedback != NULL && atoi(enable_midi_feedback) != 0;
+    g_enable_midi_feedback_sync = enable_midi_feedback != NULL && atoi(enable_midi_feedback) == 2;
+
+    // if midi feedback is enable create output midi port
+    if(g_enable_midi_feedback)
+    {
+        g_midi_out_port = jack_port_register(g_jack_global_client, "midi_out", JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0);
+
+        if (! g_midi_out_port)
+        {
+            fprintf(stderr, "can't register global jack midi-out port\n");
+            if (client == NULL)
+                jack_client_close(g_jack_global_client);
+            return ERR_JACK_PORT_REGISTER;
+        }
+    }
 #ifdef MOD_IO_PROCESSING_ENABLED
     g_audio_in1_port = jack_port_register(g_jack_global_client, "in1", JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
     g_audio_in2_port = jack_port_register(g_jack_global_client, "in2", JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
@@ -4214,6 +4364,7 @@ int effects_init(void* client)
         g_midi_cc_list[i].effect_id = ASSIGNMENT_NULL;
         g_midi_cc_list[i].symbol = NULL;
         g_midi_cc_list[i].port = NULL;
+        g_midi_cc_list[i].midiOutValue = -1;
     }
     g_midi_learning = NULL;
 
@@ -4255,8 +4406,14 @@ int effects_init(void* client)
 
     if (g_aggregated_midi_enabled)
     {
-        const char *ourportname = jack_port_name(g_midi_in_port);
-        jack_connect(g_jack_global_client, "mod-midi-merger:out", ourportname);
+        const char *ourportnamein = jack_port_name(g_midi_in_port);
+        jack_connect(g_jack_global_client, "mod-midi-merger:out", ourportnamein);
+
+        if(g_enable_midi_feedback)
+        {
+            const char *ourportnameout = jack_port_name(g_midi_out_port);
+            jack_connect(g_jack_global_client, ourportnameout, "mod-midi-broadcaster:in");
+        }
         ConnectToMIDIThroughPorts();
     }
     /* Else connect to all good hw ports (system, ttymidi and nooice) */
@@ -5888,6 +6045,28 @@ int effects_set_parameter(int effect_id, const char *control_symbol, float value
                 value = last_max;
 
             *last_prev = *last_buffer = value;
+            // if midi feedback is enabled find the correct CC and set it to be output
+            if(g_enable_midi_feedback)
+            {
+                for (int j = 0; j < MAX_MIDI_CC_ASSIGN; j++)
+                {
+                    if (g_midi_cc_list[j].effect_id == ASSIGNMENT_NULL)
+                        break;
+                    if (g_midi_cc_list[j].effect_id == ASSIGNMENT_UNUSED)
+                        continue;
+                    if (g_midi_cc_list[j].effect_id  == effect_id)
+                    { 
+                        // avoid call to strcmp and compare strings ourselves
+                        bool bEqual = false;
+                        for(const char *s1 = control_symbol, *s2 = g_midi_cc_list[j].symbol; (bEqual = *s1 == *s2) && *s1; s1++, s2++)
+                            /* empty loop*/;
+
+                        if(bEqual)
+                            SetMidiOutValue(&(g_midi_cc_list[j]));
+                    }
+                    
+                }
+            }
             return SUCCESS;
         }
 
@@ -6595,6 +6774,10 @@ int effects_midi_map(int effect_id, const char *control_symbol, int channel, int
         {
             g_midi_cc_list[i].minimum = minimum;
             g_midi_cc_list[i].maximum = maximum;
+        
+            // if midi feedback is enabled set this cc to be sent
+            if(g_enable_midi_feedback)
+                SetMidiOutValue(&(g_midi_cc_list[i]));
         }
 
         return SUCCESS;
@@ -6622,6 +6805,10 @@ int effects_midi_map(int effect_id, const char *control_symbol, int channel, int
             g_midi_cc_list[i].maximum = maximum;
             g_midi_cc_list[i].symbol = port->symbol;
             g_midi_cc_list[i].port = port;
+
+            // if midi feedback is enabled set this cc to be sent
+            if(g_enable_midi_feedback)
+                SetMidiOutValue(&(g_midi_cc_list[i]));
         }
 
         g_midi_cc_list[i].channel = channel;
@@ -7850,6 +8037,12 @@ int effects_aggregated_midi_enable(int enable)
             pthread_mutex_unlock(&g_raw_midi_port_mutex);
         }
 
+        // step7. If midi feedback enabled then connect to mod-midi-broadcaster
+        if(g_enable_midi_feedback)
+        {
+            const char *ourportnameout = jack_port_name(g_midi_out_port);
+            jack_connect(g_jack_global_client, ourportnameout, "mod-midi-broadcaster:in");
+        }
     } else {
         // step 1. remove aggregated midi clients
         jack_intclient_t merger = jack_internal_client_handle(g_jack_global_client, "mod-midi-merger", NULL);

--- a/src/effects.c
+++ b/src/effects.c
@@ -2736,16 +2736,17 @@ static int ProcessGlobalClient(jack_nframes_t nframes, void *arg)
                     }
                     break;
 
-                    // nrpn param num lsb
+                    // nrpn param value lsb
                     case 38 :
                     {
                         // if msb has already been set
                         if((g_nrpn_param_value & 0x8000) == 0)
                         {
-                            g_nrpn_param_value = (g_nrpn_param_value & 0x3F80) | mvalue;
                             highres = true;
                             controller = 0x8000 | g_nrpn_param_num;
-                            mvalue = g_nrpn_param_value;
+                            mvalue = (g_nrpn_param_value & 0x3F80) | mvalue;
+                            g_nrpn_param_value = 0xC000;   // Set so we need MSB and LSB again
+
                         }
                         else
                             continue;

--- a/src/effects.c
+++ b/src/effects.c
@@ -2503,7 +2503,7 @@ static int ProcessGlobalClient(jack_nframes_t nframes, void *arg)
     uint16_t mvalue;
     float value;
     double dvalue;
-    bool handled, highres, needs_post, nrpn = false;
+    bool handled, highres, needs_post = false;
     enum UpdatePositionFlag pos_flag = UPDATE_POSITION_IF_CHANGED;
 
 #ifdef HAVE_HYLIA
@@ -2568,6 +2568,7 @@ static int ProcessGlobalClient(jack_nframes_t nframes, void *arg)
                                 error_sending = jack_midi_event_write(buf, 0, buffer, 3);
                             }
                         }
+                        g_midi_cc_list[j].midiOutValue = -1;
                     }
                     else
                     {
@@ -2697,7 +2698,6 @@ static int ProcessGlobalClient(jack_nframes_t nframes, void *arg)
             controller = event.buffer[1];
             mvalue     = event.buffer[2];
             highres    = false;
-            nrpn       = false;
 
             if(g_enable_nrpn)
             {
@@ -2743,7 +2743,6 @@ static int ProcessGlobalClient(jack_nframes_t nframes, void *arg)
                         if((g_nrpn_param_value & 0x8000) == 0)
                         {
                             g_nrpn_param_value = (g_nrpn_param_value & 0x3F80) | mvalue;
-                            nrpn    = true;
                             highres = true;
                             controller = 0x8000 | g_nrpn_param_num;
                             mvalue = g_nrpn_param_value;


### PR DESCRIPTION
Added NRPNs for controlling parameters, including bi directional feedback.

Supports  running status (data CCs 6 & 98)
7 bit values are not supported, need both CC 6 & 98.

To keep changes minimal I overloaded controller in MIDI_CC_T, this is now 16 bits, top bit signifies NRPN rather than CC.

midioutvalue is also now also 16 bits so it can hold the 14bit NRPNs value.

env var ENABLE_MIDI_NRPN needs to be non 0 to enable.


