### PR TITLE
Shutdown effects gracefully at end of interactive mode

### DIFF
--- a/src/mod-host.c
+++ b/src/mod-host.c
@@ -835,6 +835,7 @@ int main(int argc, char **argv)
     if (interactive)
     {
         interactive_mode();
+        effects_finish(1);
         return 0;
     }
     else


### PR DESCRIPTION
Otherwise the jack client is not shut down correctly and jack complains when ending interactive mode (e.g. with EOF/ctrl-D)