### PR TITLE
add bypass monitor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ The commands supported by mod-host are:
         if bypass_value = 1 bypass effect
         if bypass_value = 0 process effect
 
+    bypass_monitor <instance_number> <status>
+        * enable bypass monitoring for a plugin
+        e.g.: bypass_monitor 0 1
+        if status = 1 monitor enabled
+        if status = 0 monitor disabled
+
     param_set <instance_number> <param_symbol> <param_value>
         * set the value of a control port
         e.g.: param_set 0 "gain" 2.5

--- a/src/effects.h
+++ b/src/effects.h
@@ -147,6 +147,7 @@ int effects_get_parameter(int effect_id, const char *control_symbol, float *valu
 int effects_set_property(int effect_id, const char *uri, const char *value);
 int effects_get_property(int effect_id, const char *uri);
 int effects_monitor_parameter(int effect_id, const char *control_symbol, const char *op, float value);
+int effects_monitor_bypass(int effect_id, int status);
 int effects_monitor_output_parameter(int effect_id, const char *control_symbol);
 int effects_bypass(int effect_id, int value);
 int effects_get_parameter_symbols(int effect_id, int output_ports, const char** symbols);

--- a/src/mod-host.c
+++ b/src/mod-host.c
@@ -226,6 +226,17 @@ static void effects_monitor_param_cb(proto_t *proto)
     protocol_response_int(resp, proto);
 }
 
+static void effects_bypass_monitor_cb(proto_t *proto)
+{
+    int resp;
+    if (monitor_status())
+        resp = effects_monitor_bypass(atoi(proto->list[1]), atoi(proto->list[2]));
+    else
+        resp = -1;
+
+    protocol_response_int(resp, proto);
+}
+
 static void effects_set_property_cb(proto_t *proto)
 {
     int resp;
@@ -680,6 +691,7 @@ static int mod_host_init(jack_client_t* client, int socket_port, int feedback_po
     protocol_add_command(EFFECT_CONNECT, effects_connect_cb);
     protocol_add_command(EFFECT_DISCONNECT, effects_disconnect_cb);
     protocol_add_command(EFFECT_BYPASS, effects_bypass_cb);
+    protocol_add_command(EFFECT_BYPASS_MON, effects_bypass_monitor_cb);
     protocol_add_command(EFFECT_PARAM_SET, effects_set_param_cb);
     protocol_add_command(EFFECT_PARAM_GET, effects_get_param_cb);
     protocol_add_command(EFFECT_PARAM_MON, effects_monitor_param_cb);

--- a/src/mod-host.h
+++ b/src/mod-host.h
@@ -62,6 +62,7 @@
 #define EFFECT_PARAM_SET     "param_set %i %s %s"
 #define EFFECT_PARAM_GET     "param_get %i %s"
 #define EFFECT_PARAM_MON     "param_monitor %i %s %s %f"
+#define EFFECT_BYPASS_MON    "bypass_monitor %i %i" //instance status
 #define EFFECT_PATCH_GET     "patch_get %i %s"
 #define EFFECT_PATCH_SET     "patch_set %i %s %s"
 #define EFFECT_LICENSEE      "licensee %i"


### PR DESCRIPTION
I am currently developing my own UI to replace mod-ui.
I needed to be aware that when a plugin is set/unset to bypassed. This way, I can update my UI.