### PR TITLE
Fixes #73.

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -57,7 +57,7 @@
 #define MESSAGE_INVALID_ARGUMENT    "invalid argument"
 
 // defines the function to send responses to sender
-#define SEND_TO_SENDER(id,msg,len)  socket_send((id),(msg),(len)+1)
+#define SEND_TO_SENDER(id,msg,len)  if(id==1)fprintf(stdin,"%s\n",msg); else socket_send((id),(msg),(len)+1)
 
 
 /*


### PR DESCRIPTION
Check if command response is for fd 1.

The PR fixes issue #73 by checking if the target id for command responses is `1` and if so, prints to stdout. This assumes stdout is '1' in the same way as `interactive_mode()` does. There is a risk that mod-host may be launched without stdout being defined as '1' and the socket having fd=1 in which case this fix wouldn't work, but the full fix is a more substantial refactor of the code to correct a lot of other assumptions. This is a pragmatic fix to allow users to use the CLI that is currently broken.