### PR TITLE
Fixes #84.

### DIFF
--- a/src/completer.c
+++ b/src/completer.c
@@ -88,6 +88,8 @@ static const char *g_commands[] = {
     "transport",
     "transport_sync",
     "output_data_ready",
+    "show_external_ui",
+    "hide_external_ui",
     "help",
     "quit",
     NULL

--- a/src/effects.c
+++ b/src/effects.c
@@ -8194,6 +8194,8 @@ int effects_show_external_ui(int effect_id)
         return ERR_ASSIGNMENT_INVALID_OP;
 
     effect_t *effect = &g_effects[effect_id];
+    if (effect->ui_handle)
+        return ERR_ASSIGNMENT_ALREADY_EXISTS;
     LilvUIs *uis = lilv_plugin_get_uis(effect->lilv_plugin);
 
     if (uis == NULL)
@@ -8295,6 +8297,34 @@ cleanup:
     return ERR_EXTERNAL_UI_UNAVAILABLE;
 
     UNUSED_PARAM(effect_id);
+#endif
+}
+
+int effects_hide_external_ui(int effect_id) {
+#ifdef WITH_EXTERNAL_UI_SUPPORT
+    if (!InstanceExist(effect_id))
+        return ERR_INSTANCE_NON_EXISTS;
+
+    effect_t *effect = &g_effects[effect_id];
+    if (effect == NULL)
+        return ERR_INSTANCE_INVALID;
+
+    if (effect->ui_desc == NULL)
+        return ERR_EXTERNAL_UI_UNAVAILABLE;
+
+    const LV2UI_Show_Interface *show_iface;
+    if ((show_iface = effect->ui_desc->extension_data(LV2_UI__showInterface)) == NULL)
+        return ERR_EXTERNAL_UI_UNAVAILABLE;
+
+    show_iface->hide(effect->ui_handle);
+    dlclose(effect->ui_handle);
+    effect->ui_desc = NULL;
+    effect->ui_handle = NULL;
+    effect->ui_idle_iface = NULL;
+    effect->ui_libhandle = NULL;
+
+    return SUCCESS;
+
 #endif
 }
 

--- a/src/effects.h
+++ b/src/effects.h
@@ -186,6 +186,7 @@ void effects_transport(int rolling, double beats_per_bar, double beats_per_minut
 int effects_transport_sync_mode(const char *mode);
 void effects_output_data_ready(void);
 int effects_show_external_ui(int effect_id);
+int effects_hide_external_ui(int effect_id);
 void effects_idle_external_uis(void);
 
 /*

--- a/src/mod-host.c
+++ b/src/mod-host.c
@@ -567,6 +567,13 @@ static void show_external_ui(proto_t *proto)
     protocol_response_int(resp, proto);
 }
 
+static void hide_external_ui(proto_t *proto)
+{
+    const int resp = effects_hide_external_ui(atoi(proto->list[1]));
+    protocol_response_int(resp, proto);
+}
+
+
 static void output_data_ready(proto_t *proto)
 {
     effects_output_data_ready();
@@ -715,6 +722,7 @@ static int mod_host_init(jack_client_t* client, int socket_port, int feedback_po
     protocol_add_command(TRANSPORT, transport);
     protocol_add_command(TRANSPORT_SYNC, transport_sync);
     protocol_add_command(SHOW_EXTERNAL_UI, show_external_ui);
+    protocol_add_command(HIDE_EXTERNAL_UI, hide_external_ui);
     protocol_add_command(OUTPUT_DATA_READY, output_data_ready);
 
     /* skip help and quit for internal client */

--- a/src/mod-host.h
+++ b/src/mod-host.h
@@ -92,6 +92,7 @@
 #define TRANSPORT            "transport %i %f %f"
 #define TRANSPORT_SYNC       "transport_sync %s"
 #define SHOW_EXTERNAL_UI     "show_external_ui %i"
+#define HIDE_EXTERNAL_UI     "hide_external_ui %i"
 #define OUTPUT_DATA_READY    "output_data_ready"
 #define HELP                 "help"
 #define QUIT                 "quit"


### PR DESCRIPTION
Check if external ui is running before allowing a new instance. Add command hide_external_ui.